### PR TITLE
fixed: Dead link to 2.1 addon folder in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ and put it in `~/Anki/addons`.
     anki.sync.SYNC_BASE = addr
     anki.sync.SYNC_MEDIA_BASE = addr + "msync/"
 
-[addons21]: https://apps.ankiweb.net/docs/addons.html#_add_on_folders
+[addons21]: https://addon-docs.ankiweb.net/#/getting-started?id=add-on-folders
 
 ### AnkiDroid
 


### PR DESCRIPTION
The old link to the addon folder for Anki 2.1 (`https://apps.ankiweb.net/docs/addons.html#_add_on_folders`) is dead.

This pull request replaces the link with the up to date one.