### PR TITLE
 fix legacy bug  and update to depend anki 2.1.36

### DIFF
--- a/src/ankisyncd/__init__.py
+++ b/src/ankisyncd/__init__.py
@@ -1,7 +1,7 @@
 import os
 import sys
 
-_homepage = "https://github.com/tsudoko/anki-sync-server"
+_homepage = "https://github.com/ankicommunity/anki-sync-server.git"
 _unknown_version = "[unknown version]"
 
 

--- a/src/ankisyncd/collection.py
+++ b/src/ankisyncd/collection.py
@@ -64,7 +64,7 @@ class CollectionWrapper:
         return col
 
     def _get_collection(self):
-        col = anki.storage.Collection(self.path)
+        col = anki.storage.Collection(self.path, server=True)
 
         # Ugly hack, replace default media manager with our custom one
         col.media.close()

--- a/src/ankisyncd/sync.py
+++ b/src/ankisyncd/sync.py
@@ -194,7 +194,7 @@ from notes where %s""" % lim, self.maxUsn)
         self.col.remCards(graves['cards'], notes=False)
         # and decks
         for oid in graves['decks']:
-            self.col.decks.rem(oid, childrenToo=False)
+            self.col.decks.rem(oid)
 
         self.col.server = False
 

--- a/src/ankisyncd/sync.py
+++ b/src/ankisyncd/sync.py
@@ -185,8 +185,6 @@ from notes where %s""" % lim, self.maxUsn)
         return dict(cards=cards, notes=notes, decks=decks)
 
     def remove(self, graves):
-        # pretend to be the server so we don't set usn = -1
-        self.col.server = True
 
         # notes first, so we don't end up with duplicate graves
         self.col._remNotes(graves['notes'])
@@ -196,7 +194,6 @@ from notes where %s""" % lim, self.maxUsn)
         for oid in graves['decks']:
             self.col.decks.rem(oid)
 
-        self.col.server = False
 
     # Models
     ##########################################################################

--- a/src/ankisyncd/sync_app.py
+++ b/src/ankisyncd/sync_app.py
@@ -113,7 +113,7 @@ class SyncCollectionHandler(Syncer):
     # server-side deletions to be returned by start
     def start(self, minUsn, lnewer, graves={"cards": [], "notes": [], "decks": []}, offset=None):
         if offset is not None:
-            raise NotImplementedError('You are using the experimental V2 scheduler, which is not supported by the server.')
+            pass
         self.maxUsn = self.col._usn
         self.minUsn = minUsn
         self.lnewer = not lnewer

--- a/src/ankisyncd/sync_app.py
+++ b/src/ankisyncd/sync_app.py
@@ -243,6 +243,9 @@ class SyncMediaHandler:
         media_to_add = []
         usn = self.col.media.lastUsn()
         oldUsn = usn
+        media_dir = self.col.media.dir()
+        os.makedirs(media_dir, exist_ok=True)
+
         for i in zip_file.infolist():
             if i.filename == "_meta":  # Ignore previously retrieved metadata.
                 continue
@@ -250,7 +253,7 @@ class SyncMediaHandler:
             file_data = zip_file.read(i)
             csum = anki.utils.checksum(file_data)
             filename = self._normalize_filename(meta[int(i.filename)][0])
-            file_path = os.path.join(self.col.media.dir(), filename)
+            file_path = os.path.join(media_dir, filename)
 
             # Save file to media directory.
             with open(file_path, 'wb') as f:

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,5 +1,5 @@
-anki==2.1.32
-ankirspy==2.1.32
+anki==2.1.36
+ankirspy==2.1.36
 beautifulsoup4==4.9.1
 certifi==2020.6.20
 chardet==3.0.4


### PR DESCRIPTION
* update ankisyncd _homepage
* enable V2 scheduler 
* update dependency anki and ankirspy to 2.1.36(06292a45f304fc3c9ea2ef09789b090b2e368016),
    with patch  align rslib get_subnode impl with anki pythonapi find_deck_in_tree #805  
    https://github.com/ankitects/anki/pull/805
    once not apply the patch , the nestdeck sync will fail,lead to recheck database errro on desktop.
    So you can only use the nonnestdeck without the patch.
* fix the remove deck lead server crash issue #28,change intruduced after 3.1.28 f592672fa
* fix: once client items in graves have been remove in the server,need update graves usn as maxusn
    avoid sync serve log: sanity check failed with server: graves had usn = -1 such as issue #28
    second comment
* fix client add then delete item then sync issue, deck/card/note must not been synced after client add
* ensure mediadir exsit in the case full sync ok after delete server collection dir


Note: Look like the bug intruduced after the 2.1.28, so the update dependency is not related with the bug fixed.

Now test to be working with anki 2.1.36 desktop , AnkiDroid 2.13.5.

