### PR TITLE
Fix: server side graves's usn need not set as -1

### DIFF
--- a/src/ankisyncd/collection.py
+++ b/src/ankisyncd/collection.py
@@ -64,7 +64,7 @@ class CollectionWrapper:
         return col
 
     def _get_collection(self):
-        col = anki.storage.Collection(self.path)
+        col = anki.storage.Collection(self.path, server=True)
 
         # Ugly hack, replace default media manager with our custom one
         col.media.close()

--- a/src/ankisyncd/sync.py
+++ b/src/ankisyncd/sync.py
@@ -185,8 +185,6 @@ from notes where %s""" % lim, self.maxUsn)
         return dict(cards=cards, notes=notes, decks=decks)
 
     def remove(self, graves):
-        # pretend to be the server so we don't set usn = -1
-        self.col.server = True
 
         # notes first, so we don't end up with duplicate graves
         self.col._remNotes(graves['notes'])
@@ -196,7 +194,6 @@ from notes where %s""" % lim, self.maxUsn)
         for oid in graves['decks']:
             self.col.decks.rem(oid, childrenToo=False)
 
-        self.col.server = False
 
     # Models
     ##########################################################################


### PR DESCRIPTION
once client items in graves have been remove
in the server,need update graves usn as maxusn
avoid sync serve log: sanity check failed with
server: graves had usn = -1 such as 
issue #28 second comment