### PR TITLE
Make ankisyncctl use python3 in shebang

### DIFF
--- a/src/ankisyncctl.py
+++ b/src/ankisyncctl.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 import sys
 import getpass


### PR DESCRIPTION
Most Linux distributions use `python3` for Python 3, and there isn't a consensus what `python` means.

This changes the shebang to `python3`, which also align with `migrate_user_tables.py`.