### PR TITLE
fix:'NoneType' object is not subscriptable_41_

### DIFF
--- a/src/ankisyncd/sync_app.py
+++ b/src/ankisyncd/sync_app.py
@@ -121,6 +121,10 @@ class SyncCollectionHandler(Syncer):
         self.minUsn = minUsn
         self.lnewer = not lnewer
         lgraves = self.removed()
+        # convert grave:None to {'cards': [], 'notes': [], 'decks': []}
+        #     because req.POST['data'] returned value of grave is None     
+        if graves==None:
+            graves={'cards': [], 'notes': [], 'decks': []}
         self.remove(graves)
         return lgraves
 


### PR DESCRIPTION
this PR may be inconsistent with previous version.
@wsgify
    def __call__(self, req):
        data = req.POST['data'].file.read()
         data = self._decode_data(data, compression)

return value of grave in data is None
so coerce it to default value
