### PR TITLE
fix:delete non-empty deck cause sanity check error

### DIFF
--- a/src/ankisyncd/sync.py
+++ b/src/ankisyncd/sync.py
@@ -124,7 +124,15 @@ select id from notes where mid = ?) limit 1"""
                 return "model had usn = -1"
         if found:
             self.col.models.save()
-        self.col.sched.reset()
+        # relace self.col.sched.reset() with following code 
+        # in fn reset() ,self.col.decks.update_active() will  go away as
+        # anki module 2.1.44 comments,so remove this sentence
+        self.col.sched._updateCutoff()
+        self.col.sched._reset_counts()
+        self.col.sched._resetLrn()
+        self.col.sched._resetRev()
+        self.col.sched._resetNew()
+        self.col.sched._haveQueues = True
         # check for missing parent decks
         #self.col.sched.deckDueList()
         # return summary of deck


### PR DESCRIPTION
bug description:create a deck and add some cards ,sync,and delete this deck.this will cause sanity check error and thus a Check database window popping up. Yet,after a while ,it's normal to sync.

when: this issue appears in both version 2.1.45 and 2.1.46,others not found.

fix it by delete some sentence in def reset() 