### PR TITLE
Fix addon-folder doc link

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ and put it in `~/Anki/addons`.
     anki.sync.SYNC_BASE = addr
     anki.sync.SYNC_MEDIA_BASE = addr + "msync/"
 
-[addons21]: https://addon-docs.ankiweb.net/#/getting-started?id=add-on-folders
+[addons21]: https://addon-docs.ankiweb.net/addon-folders.html
 
 ### AnkiDroid
 


### PR DESCRIPTION
The original link directs to an introduction page, which has no information about add-on folder:
![image](https://user-images.githubusercontent.com/24320926/171550905-efe5dea7-b8a7-455c-98cb-eb130e2004c4.png)

I corrected the link and now it directs to the "Add-on Folders" chapter:
![image](https://user-images.githubusercontent.com/24320926/171550975-c93e6ffe-cf97-4969-a093-7d5118b17a0a.png)
